### PR TITLE
fix error message encoding

### DIFF
--- a/src/macos.rs
+++ b/src/macos.rs
@@ -7,6 +7,7 @@ use core_foundation::string::CFString;
 use debug_print::debug_println;
 use lru::LruCache;
 use parking_lot::Mutex;
+use std::io::Error;
 
 static GET_SELECTED_TEXT_METHOD: Mutex<Option<LruCache<String, u8>>> = Mutex::new(None);
 
@@ -128,12 +129,14 @@ fn get_selected_text_by_clipboard_using_applescript() -> Result<String, Box<dyn 
         let content = content.trim();
         Ok(content.to_string())
     } else {
-        let err = output
-            .stderr
-            .into_iter()
-            .map(|c| c as char)
-            .collect::<String>()
-            .into();
-        Err(err)
+        let d = String::from_utf8(output.stderr)
+            .unwrap_or_else(|_| "Failed to read stderr".to_string());
+
+        let err = Error::new(
+            std::io::ErrorKind::Other,
+            format!("AppleScript failed: {}", d),
+        );
+
+        Err(Box::new(err))
     }
 }


### PR DESCRIPTION
My macOS' language is set to Chinese, so the `osascript` will throw error to the terminal or other log sink in Chinese. We have to appropriately encode the error message to make it readable :-)

Otherwise, the error message looks like
```
error occurred while getting the selected text, error: 507:541: execution error: âSystem Eventsâéå°ä¸ä¸ªéè¯¯ï¼âosascriptâä¸åè®¸åéæé®ã (1002)
```